### PR TITLE
Add Dockerfile for CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+FROM ros:crystal
+
+# install tools
+RUN apt-get update && apt-get install -q -y \
+      build-essential \
+      cmake \
+      git \
+      python3-colcon-common-extensions \
+      python3-vcstool \
+      wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# install rust
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=1.33.0
+RUN set -eux; \
+    wget -O rustup-init "https://sh.rustup.rs"; \
+    chmod +x rustup-init; \
+    ./rustup-init -y \
+      --no-modify-path \
+      --default-toolchain $RUST_VERSION; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+
+# copy package package repo
+ENV ROS_WS /opt/ros_ws
+RUN mkdir -p $ROS_WS/src
+WORKDIR $ROS_WS
+COPY ./ src/ros2_rust
+
+# install package dependencies
+RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
+    apt-get update && \
+    rosdep install -q -y \
+      --from-paths \
+        src \
+      --ignore-src \
+    && rm -rf /var/lib/apt/lists/*
+
+# build package source
+ARG CMAKE_BUILD_TYPE=Release
+RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
+    colcon build \
+      --symlink-install \
+      --cmake-args \
+        -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
+
+# source workspace from entrypoint
+RUN sed --in-place --expression \
+      '$isource "$ROS_WS/install/setup.bash"' \
+      /ros_entrypoint.sh


### PR DESCRIPTION
Hello @lelongg , I see you've been actively working on your fork of ros2_rust. I'm just diving into rust and would like to help out. I tried building your master branch, but hit some snags about clang. I'm not sure how clang got selected over gcc as I'm still catching up with the codebase, but I created a Dockerfile we could use for CI to reproduce the issue. 

<details>

```
# build/rclrs_examples/rclrs_examples-prefix/src/rclrs_examples-stamp/rclrs_examples-build-err.log
    Updating crates.io index
 Downloading crates ...
  Downloaded downcast v0.10.0
  Downloaded failure v0.1.5
  Downloaded bindgen v0.45.0
  Downloaded failure_derive v0.1.5
  Downloaded libc v0.2.49
  Downloaded backtrace v0.3.14
  Downloaded clang-sys v0.26.4
  Downloaded regex v1.1.2
  Downloaded which v2.0.1
  Downloaded env_logger v0.6.0
  Downloaded lazy_static v1.3.0
  Downloaded peeking_take_while v0.1.2
  Downloaded cexpr v0.3.4
  Downloaded libloading v0.5.0
  Downloaded aho-corasick v0.6.10
  Downloaded memchr v2.2.0
  Downloaded syn v0.15.27
  Downloaded rustc-demangle v0.1.13
  Downloaded regex-syntax v0.6.5
  Downloaded utf8-ranges v1.0.2
  Downloaded thread_local v0.3.6
  Downloaded synstructure v0.10.1
  Downloaded termcolor v1.0.4
  Downloaded backtrace-sys v0.1.28
  Downloaded ucd-util v0.1.3
  Downloaded cc v1.0.30
  Downloaded nom v4.2.1
   Compiling proc-macro2 v0.4.27
   Compiling unicode-xid v0.1.0
   Compiling libc v0.2.49
   Compiling cc v1.0.30
   Compiling memchr v2.2.0
   Compiling autocfg v0.1.2
   Compiling failure_derive v0.1.5
   Compiling glob v0.2.11
   Compiling ucd-util v0.1.3
   Compiling regex v1.1.2
   Compiling lazy_static v1.3.0
   Compiling cfg-if v0.1.6
   Compiling rustc-demangle v0.1.13
   Compiling utf8-ranges v1.0.2
   Compiling quick-error v1.2.2
   Compiling unicode-width v0.1.5
   Compiling strsim v0.7.0
   Compiling bitflags v1.0.4
   Compiling termcolor v1.0.4
   Compiling vec_map v0.8.1
   Compiling ansi_term v0.11.0
   Compiling bindgen v0.45.0
   Compiling peeking_take_while v0.1.2
   Compiling downcast v0.10.0
   Compiling backtrace v0.3.14
   Compiling regex-syntax v0.6.5
   Compiling clang-sys v0.26.4
   Compiling log v0.4.6
   Compiling thread_local v0.3.6
   Compiling humantime v1.2.0
   Compiling textwrap v0.10.0
   Compiling aho-corasick v0.6.10
   Compiling nom v4.2.1
   Compiling atty v0.2.11
   Compiling backtrace-sys v0.1.28
   Compiling libloading v0.5.0
   Compiling clap v2.32.0
   Compiling cexpr v0.3.4
   Compiling quote v0.6.11
   Compiling syn v0.15.27
   Compiling synstructure v0.10.1
   Compiling env_logger v0.6.0
   Compiling failure v0.1.5
   Compiling which v2.0.1
   Compiling rclrs_common v0.1.0 (/home/ubuntu/ws/rclrs/install/rclrs_common/share/rclrs_common/rust)
   Compiling rclrs v0.1.0 (/home/ubuntu/ws/rclrs/install/rclrs/share/rclrs/rust)
error: failed to run custom build command for `rclrs v0.1.0 (/home/ubuntu/ws/rclrs/install/rclrs/share/rclrs/rust)`
process didn't exit successfully: `/home/ubuntu/ws/rclrs/build/rclrs_examples/ament_cargo/rclrs_examples/target/release/build/rclrs-beb299c895f992c8/build-script-build` (exit code: 101)
--- stdout
cargo:rustc-link-search=native=/home/ubuntu/ws/rclrs/install/rosidl_generator_rs/lib
cargo:rustc-link-search=native=/home/ubuntu/ws/rclrs/install/rclrs/lib
cargo:rustc-link-search=native=/home/ubuntu/ws/rclrs/install/rclrs_common/lib
cargo:rustc-link-search=native=/home/ubuntu/ws/rclrs/install/ament_cmake_export_crates/lib
cargo:rustc-link-search=native=/home/ubuntu/ws/ros2_bbr/install/my_rosbag2_storage_default_plugins/lib
cargo:rustc-link-search=native=/home/ubuntu/ws/ros2_bbr/install/bbr_sawtooth_bridge/lib
cargo:rustc-link-search=native=/home/ubuntu/ws/ros2_bbr/install/bbr_system_tests/lib
cargo:rustc-link-search=native=/home/ubuntu/ws/ros2_bbr/install/bbr_rosbag2_storage_plugin/lib
cargo:rustc-link-search=native=/home/ubuntu/ws/ros2_bbr/install/bbr_protobuf/lib
cargo:rustc-link-search=native=/home/ubuntu/ws/ros2_bbr/install/bbr_msgs/lib
cargo:rustc-link-search=native=/home/ubuntu/ws/ros2_bbr/install/bbr_common/lib
cargo:rustc-link-search=native=/opt/ros/crystal/lib
cargo:rustc-link-lib=dylib=rcl
cargo:rustc-link-lib=dylib=rcl_logging_noop
cargo:rustc-link-lib=dylib=rcutils
cargo:rustc-link-lib=dylib=rmw
cargo:rustc-link-lib=dylib=rmw_implementation

--- stderr
thread 'main' panicked at 'Unable to find libclang: "couldn\'t find any valid shared libraries matching: [\'libclang.so\', \'libclang-*.so\', \'libclang.so.*\'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"', src/libcore/result.rs:997:5
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
``` 